### PR TITLE
Update for FVTT 11

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
 	"version": "1.4.2",
 	"compatibility": {
 		"minimum": 10,
-		"verified": "10"
+		"verified": "11"
 	},
 	"authors": [
 		{

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -17,8 +17,10 @@ export class gridUtils {
     if (evt) {
       result = evt.data.getLocalPosition(canvas.app.stage)
     } else {
-      let mouse = canvas.app.renderer.plugins.interaction.mouse;
-      result = mouse.getLocalPosition(canvas.app.stage);
+      const { app: { plugins: { interaction } } } = canvas;
+      // Older version of Foundry use mouse, newer versions use pointer.
+      let pointer = interaction.mouse || interaction.pointer;
+      result = pointer.getLocalPosition(canvas.app.stage);
     }
 
     return result;


### PR DESCRIPTION
Uses feature detection to use `pointer` instead of `mouse` object when available.  This allows the module to work with <10 as well as >11 versions.

Addresses: https://github.com/jbhaywood/scaleGrid/issues/7

I know this is effectively a duplicate of https://github.com/jbhaywood/scaleGrid/pull/8 but I needed this fix now and I wasn't sure how long the pre-existing PR would take to be addressed.  Feel free to take or leave either one.  My feelings will not be hurt :) 